### PR TITLE
fix(ControlInput): replace root element

### DIFF
--- a/src/components/ControlInput.vue
+++ b/src/components/ControlInput.vue
@@ -22,7 +22,7 @@ function onChange(value: string) {
 </script>
 
 <template>
-  <template v-if="control.visible">
+  <div v-if="control.visible">
     <ColorControl
       v-if="control.type === 'color'"
       :label="control.label"
@@ -81,5 +81,5 @@ function onChange(value: string) {
       :control="control"
       @change="onChange"
     />
-  </template>
+  </div>
 </template>


### PR DESCRIPTION
## Description

**Summary**

To avoid Vue complaining (rightly so) about fall-through attributes to fragments, the component now renders a div as a root

Closes #86

## Changes

**What kind of change does this PR introduce?** (check at least one by adding an "x" between the brackets)

- [ ] Build-related changes
- [X] Bugfix
- [ ] Code style update
- [ ] Feature
- [ ] Refactor
- [ ] Style: 
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No


**The PR fulfils these requirements:**

- [X] TresJS [code of conduct](https://github.com/Tresjs/leches/blob/main/CODE_OF_CONDUCT.md)