### PR TITLE
docs: fix typo in style imports

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -27,7 +27,7 @@ This package is on heavy WIP and it's not ready for production. Expect possible 
 ```html
 <script lang="ts" setup>
 import { useControls, TresLeches } from '@tresjs/leches'
-import '@tresjs/leches/style'
+import '@tresjs/leches/styles'
 
 useControls({
   awiwi: true,


### PR DESCRIPTION
Since we have <code>style<b>s</b></code> rather than `style` in the exports map in `package.json`

https://github.com/Tresjs/leches/blob/428248a3b7cc4d41b0e651dac5f24d67c3fbf470/package.json#L16-L23