### PR TITLE
fix: dispose-controls-on-unmount

### DIFF
--- a/src/components/TresLeches.vue
+++ b/src/components/TresLeches.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { Ref } from 'vue'
-import { computed, ref, toRefs, unref } from 'vue'
+import { computed, onUnmounted, ref, toRefs, unref } from 'vue'
 import { useWindowSize } from '@vueuse/core'
 import { UseDraggable } from '../composables/useDraggable/component'
-import { useControlsProvider } from '../composables/useControls'
+import { dispose, useControlsProvider } from '../composables/useControls'
 import type { Control } from '../types'
 import Folder from './Folder.vue'
 
@@ -24,6 +24,11 @@ const handle = ref<HTMLElement | null>(null)
 const controls = useControlsProvider(uuid?.value)
 
 defineExpose(controls)
+
+// Add cleanup when component is unmounted
+onUnmounted(() => {
+  dispose(uuid?.value)
+})
 
 function onChange(key: Ref<string>, value: string) {
   controls[unref(key)].value = value as any

--- a/src/composables/useControls.ts
+++ b/src/composables/useControls.ts
@@ -1,4 +1,4 @@
-import { isReactive, isRef, provide, reactive, ref, toRefs } from 'vue'
+import { isReactive, isRef, provide, reactive, ref, type Ref, toRefs } from 'vue'
 import type { Control } from '../types'
 
 export const CONTROLS_CONTEXT_KEY = Symbol('CONTROLS_CONTEXT_KEY')

--- a/tests/useControls.test.ts
+++ b/tests/useControls.test.ts
@@ -1,6 +1,8 @@
-import { isRef } from 'vue'
+import { isRef, nextTick } from 'vue'
 import { afterEach, describe, expect, it } from 'vitest'
-import { dispose, useControls } from '/@/composables/useControls'
+import { dispose, useControls, useControlsProvider } from '/@/composables/useControls'
+import { mount } from '@vue/test-utils'
+import { TresLeches } from '/@/'
 
 describe('useControls', () => {
   afterEach(() => {
@@ -67,6 +69,25 @@ describe('useControls', () => {
       })
       expect(isRef(test)).toBe(true)
       expect(test.value).toBe(1)
+    })
+  })
+
+  describe('cleanup', () => {
+    it('should dispose controls when TresLeches component is unmounted', async () => {
+      // First mount TresLeches and create some controls
+      const wrapper = mount(TresLeches)
+      useControls({ test: true })
+
+      // Verify controls exist in the store
+      const controls = useControlsProvider()
+      expect(Object.keys(controls)).toHaveLength(1)
+
+      // Unmount TresLeches
+      wrapper.unmount()
+      await nextTick()
+
+      // Verify controls were disposed
+      expect(Object.keys(controls)).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
- Implemented cleanup logic in the TresLeches component to dispose of controls when the component is unmounted.
- Updated useControls.ts to include type imports for better type safety.
- Enhanced tests to verify that controls are properly disposed of upon unmounting the TresLeches component.